### PR TITLE
Add JDBC reading and writing to basic Spark pipeline

### DIFF
--- a/sample_db.sql
+++ b/sample_db.sql
@@ -1,0 +1,51 @@
+-- Sample PostgreSQL DB creation script used as data source for basic
+-- ETL code.
+
+-- Cleanup existing objects to make script idempotent.
+DROP TABLE IF EXISTS transactions;
+DROP TABLE IF EXISTS daily_transaction_stats;
+DROP ROLE IF EXISTS "test";
+
+CREATE TABLE transactions (
+  id SERIAL PRIMARY KEY,
+  customer_id integer NOT NULL,
+  amount integer NOT NULL,
+  purchased_at timestamp without time zone NOT NULL
+);
+
+CREATE TABLE daily_transaction_stats (
+  customer_id integer NOT NULL,
+  date date NOT NULL,
+  amount integer NOT NULL,
+  PRIMARY KEY (customer_id, date)
+);
+
+-- Example code will hardcode this user. For example purposes
+-- we don't need a more detailed ACL.
+CREATE ROLE "test" WITH SUPERUSER LOGIN PASSWORD 'test';
+
+-- Test transactions
+
+-- Totals
+-- Day 1: 1180
+-- Day 2: 96
+-- Day 3: 183
+-- Customer 1
+-- Day 1: 180
+-- Day 2: 96
+-- Day 3: 128
+-- Customer 2
+-- Day 1: 1000
+-- Day 2: 0
+-- Day 3: 55
+INSERT INTO "transactions" (customer_id, amount, purchased_at) VALUES
+(1, 55, '2017-03-01 09:00:00'),
+(1, 125, '2017-03-01 10:00:00'),
+(1, 32, '2017-03-02 13:00:00'),
+(1, 64, '2017-03-02 15:00:00'),
+(1, 128, '2017-03-03 10:00:00'),
+(2, 333, '2017-03-01 09:00:00'),
+(2, 334, '2017-03-01 09:01:00'),
+(2, 333, '2017-03-01 09:02:00'),
+(2, 11, '2017-03-03 20:00:00'),
+(2, 44, '2017-03-03 20:15:00');

--- a/spark/basic_sql_reader.py
+++ b/spark/basic_sql_reader.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+"""
+Apache Spark program that uses a SQL query as data source to feed into spark.
+"""
+
+from pyspark.sql import SparkSession
+
+logFile = "/usr/local/spark/README.md"
+spark = SparkSession.builder.appName("BasicSQL").master("local").getOrCreate()
+logData = spark.read.text(logFile).cache()
+
+numAs = logData.filter(logData.value.contains('a')).count()
+numBs = logData.filter(logData.value.contains('b')).count()
+
+print("Lines with a: %i, lines with b: %i" % (numAs, numBs))
+
+spark.stop()

--- a/spark/basic_sql_reader.py
+++ b/spark/basic_sql_reader.py
@@ -2,6 +2,8 @@
 
 """
 Apache Spark program that uses a SQL query as data source to feed into spark.
+
+Intended to be run using spark-submit [this py file].
 """
 
 from pyspark.sql import SparkSession

--- a/spark/basic_sql_reader.py
+++ b/spark/basic_sql_reader.py
@@ -9,13 +9,18 @@ instance:
   --driver-class-path [path to]/postgresql-42.1.4.jar
 """
 
+from datetime import datetime
 from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, date_format, udf
+from pyspark.sql.types import DateType
 
 spark = SparkSession \
     .builder \
-    .appName("Basic JDBC reader") \
+    .appName("Basic JDBC read / aggregate / write pipeline") \
     .getOrCreate()
 
+# Step #1
+# Read a DataFrame by getting all rows from the transactions table.
 df = spark \
     .read \
     .format("jdbc") \
@@ -25,7 +30,52 @@ df = spark \
     .option("dbtable", "transactions") \
     .load()
 
-df.printSchema()
+# Step 2
+# Transform / aggregate data
 
-sumByCustomer = df.groupBy("customer_id").sum()
-sumByCustomer.show()
+# The transactions table contains timestamps that are more granular than the
+# daily aggregation expected in the output table (at least that's what the
+# example is trying to do).
+#
+# The withColumn method will return a new data frame with one new column.
+# In 2 steps we first transform timestamp to string and then to a proper
+# spark date object.
+string_to_date = \
+    udf(lambda text_date: datetime.strptime(text_date,
+        '%m/%d/%Y'), DateType())
+
+df = df.withColumn("date_string", date_format(col("purchased_at"), 'MM/dd/yyyy'))
+df = df.withColumn("date", string_to_date(df.date_string))
+
+# With data properly formatted, group by customer and aggregate, which is what
+# we want to write.
+
+sum_df = df.groupBy("customer_id", "date").sum()
+stats_df = sum_df.select(col('customer_id'), col('date'),
+        col('sum(amount)').alias('amount'))
+
+# Step 3
+# Generate output
+
+# Print the contents of the Spark Data Frame to check everything is fine.
+stats_df.printSchema()
+stats_df.show()
+
+# Write to the database. It is assumed that the schema of the data frame matches
+# the schema of the DB table.
+#
+# Note on mode('append'): Ideally we want to just update the (customer, date)
+# pairs to make the program idempotent. In practice, this allows us to update
+# stats when new data flows in or is corrected. However UPDATE/INSERT conceptual
+# operations are not supported by Spark. For now we just write assuming that
+# there's no primary key collision. A more elaborate program can do something
+# like removing data for some date D and then inserting for that date using this
+# perogram.
+stats_df.write \
+    .mode('append') \
+    .format("jdbc") \
+    .option("url", "jdbc:postgresql://localhost/jesquivel") \
+    .option("user", "test") \
+    .option("password", "test") \
+    .option("dbtable", "daily_transaction_stats") \
+    .save()


### PR DESCRIPTION
Add a sample database with toy customer transactions, read and aggregate them daily in a Spark pipeline, and then write back to a table that is intended to hold those aggregates